### PR TITLE
Fix ScaleFromStep handling for scientific notation steps

### DIFF
--- a/core/numutil.go
+++ b/core/numutil.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"math/big"
+	"strconv"
 	"strings"
 )
 
@@ -26,10 +27,43 @@ func ScaleFromStep(step string) int {
 	if step == "" {
 		return 0
 	}
-	idx := strings.IndexByte(step, '.')
-	if idx < 0 {
+
+	mantissa := step
+	exponent := 0
+	if idx := strings.IndexAny(mantissa, "eE"); idx >= 0 {
+		mantissaPart := strings.TrimSpace(mantissa[:idx])
+		exponentPart := strings.TrimSpace(mantissa[idx+1:])
+		if mantissaPart == "" {
+			return 0
+		}
+		if exp, err := strconv.Atoi(exponentPart); err == nil {
+			exponent = exp
+			mantissa = mantissaPart
+		} else {
+			// If the exponent is malformed we fall back to using the raw string.
+			mantissa = mantissaPart
+		}
+	}
+
+	if mantissa == "" {
 		return 0
 	}
-	frac := strings.TrimRight(step[idx+1:], "0")
-	return len(frac)
+	if mantissa[0] == '+' || mantissa[0] == '-' {
+		mantissa = mantissa[1:]
+	}
+	if mantissa == "" {
+		return 0
+	}
+
+	decimals := 0
+	if idx := strings.IndexByte(mantissa, '.'); idx >= 0 {
+		frac := strings.TrimRight(mantissa[idx+1:], "0")
+		decimals = len(frac)
+	}
+
+	scale := decimals - exponent
+	if scale < 0 {
+		scale = 0
+	}
+	return scale
 }

--- a/core/numutil_test.go
+++ b/core/numutil_test.go
@@ -1,0 +1,24 @@
+package core
+
+import "testing"
+
+func TestScaleFromStep(t *testing.T) {
+	tests := []struct {
+		step string
+		want int
+	}{
+		{"", 0},
+		{"1", 0},
+		{"0.0100", 2},
+		{"1e-3", 3},
+		{"2.500e-3", 4},
+		{"5e2", 0},
+		{"  1E-6 ", 6},
+	}
+
+	for _, tt := range tests {
+		if got := ScaleFromStep(tt.step); got != tt.want {
+			t.Errorf("ScaleFromStep(%q) = %d, want %d", tt.step, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- extend `core.ScaleFromStep` to correctly interpret decimal steps expressed in scientific notation
- add unit tests covering exponent-based step strings and existing decimal cases

## Testing
- `go test ./core`


------
https://chatgpt.com/codex/tasks/task_e_68e24edeee008322a577f01768d2a130